### PR TITLE
Use the actual object name the example is using

### DIFF
--- a/documentation/src/pages/main/template.pug
+++ b/documentation/src/pages/main/template.pug
@@ -485,7 +485,7 @@ div.documentation
     // In your VueJS component.
 
     data: () => ({
-      slides: [
+      slides3: [
         {
           title: 'Slide 1',
           content: 'Slide 1 content.'
@@ -498,9 +498,9 @@ div.documentation
     }),
     methods: {
       appendSlide () {
-        this.slides.push({
-          title: `Programmagically appended slide ${this.slides.length + 1}`,
-          content: `Programmagically appended slide ${this.slides.length + 1} content.`
+        this.slides3.push({
+          title: `Programmagically appended slide ${this.slides3.length + 1}`,
+          content: `Programmagically appended slide ${this.slides3.length + 1} content.`
         })
       },
       removeSlide () {


### PR DESCRIPTION
The example is using `slides3` but the example code is using `slides`.