### PR TITLE
bugfix slide if no bullet / one slide available

### DIFF
--- a/src/components/VueperSlides.vue
+++ b/src/components/VueperSlides.vue
@@ -722,7 +722,7 @@ export default {
           if (this.isReady && !jumping) this.emit('slide')
         }
 
-        if (this.isReady && this.conf.bullets && !autoPlaying && !jumping && this.$refs.bullet[this.slides.current]) {
+        if (this.isReady && this.conf.bullets && !autoPlaying && !jumping && this.$refs.bullet && this.$refs.bullet[this.slides.current]) {
           this.$refs.bullet[this.slides.current].focus()
         }
       }


### PR DESCRIPTION
Just discovered a bug if there were no bullets presented. This happend to me, every time I have used only one slide, that was not in infinite mode.

So there was an uncaught exception, every time I tried to slide the element.

Have fixed this for you :+1: 