### PR TITLE
Update documentation after first usage

### DIFF
--- a/src/documentation/index.vue
+++ b/src/documentation/index.vue
@@ -449,7 +449,7 @@
       &lt;vueper-slide
         v-for="(slide, i) in slides"
         :key="i"
-        :image="'images/' + slide.image"
+        :image="slide.image"
         :title="slide.title"
         :content="slide.content" /&gt;
     &lt;/vueper-slides&gt;
@@ -526,7 +526,7 @@
       &lt;vueper-slide
         v-for="(slide, i) in slides"
         :key="i"
-        :image="'images/' + slide.image"
+        :image="slide.image"
         :title="slide.title"
         :content="slide.content"
         :link="slide.link" /&gt;
@@ -1304,7 +1304,7 @@
     draggingDistance:         [Number],          default: null
     duration:                 [Number, String],  default: 4000
     fade:                     [Boolean],         default: false
-    fixedHeight:              [Boolean, Number], default: false
+    fixedHeight:              [Boolean, String], default: false
     fractions:                [Boolean],         default: false
     gap:                      [Number],          default: 0
     infinite:                 [Boolean],         default: true


### PR DESCRIPTION
2 minors correction of the documentation

1. parameters `fixedHeight` supports `Boolean` and `String` (Not `Number`)
2. if images are loaded with `require()`, the props should not contain `'images/' + `